### PR TITLE
Add custom mapping options and Style Map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ Thumbs.db
 
 #data unprocessed
 2021-Agri-Preprocessed
+
+#history
+.history

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1,7 +1,7 @@
 #root {
+  display: flex;
   max-width: 100vw;
   margin: 0 auto;
-  padding: 2rem;
   text-align: center;
 }
 

--- a/client/src/components/geoJSONMap.tsx
+++ b/client/src/components/geoJSONMap.tsx
@@ -1,44 +1,79 @@
-import React from 'react';
-import { Feature, Geometry } from 'geojson';
-import { MapContainer, TileLayer, GeoJSON } from 'react-leaflet';
-import L from 'leaflet';
+/**-------***-------***-------***-------***-------
+ ** Overview: 
+ * The `GeoJSONMap` React component, in TypeScript using `react-leaflet`, displays a map from GeoJSON data. 
+ * It styles features, shows popups with their properties, and adjusts the map view to fit the GeoJSON boundaries. 
+ * A `FitBounds` component within it calculates and sets these boundaries based on the GeoJSON data provided as a prop.
+ * -------***-------***-------***-------***-------*/
+
+import React, { useEffect } from 'react';
+import { MapContainer, GeoJSON, useMap } from 'react-leaflet';
+import { GeoJsonObject, Feature, Geometry } from 'geojson';
 import 'leaflet/dist/leaflet.css';
-import { GeoJsonObject } from 'geojson';
+import L from 'leaflet';
 
 
+// Defining a custom interface for GeoJSON features with additional properties.
 interface GeoJSONFeature extends Feature<Geometry> {
   properties: { [key: string]: unknown };
 }
 
-// props type to accept GeoJSON data directly
+// Props for our GeoJSONMap component, expecting geoJsonData.
 interface GeoJSONMapProps {
   geoJsonData: GeoJsonObject | null;
 }
 
+// The main component to render our map and GeoJSON data. 
 const GeoJSONMap: React.FC<GeoJSONMapProps> = ({ geoJsonData }) => {
-  // custom styles for the GeoJSON layer
+  // Custom styles for our GeoJSON features - let's make it look nice and clear!
   const geoJsonStyle = {
-    color: "#4a83ec",
+    fillColor: "beige",
     weight: 1,
-    fillColor: "#1a1d62",
+    color: 'black',
     fillOpacity: 0.5,
   };
-
-  // Function to create a popup for features
+  
+  // Function to create popups for each feature on our map.
   const onEachFeature = (feature: GeoJSONFeature, layer: L.Layer) => {
+    // Adding popups with property details, if available.
     if (feature.properties) {
       layer.bindPopup(Object.keys(feature.properties).map(key => 
         `<strong>${key}</strong>: ${feature.properties[key]}`).join('<br />'));
     }
   };
 
+  // A component to automatically adjust the map view to fit all our GeoJSON features.
+  const FitBounds = ({ data }: { data: GeoJsonObject }) => {
+    const map = useMap();
+
+    useEffect(() => {
+      // Creating a layer from our GeoJSON data to calculate bounds.
+      const geoJsonLayer = L.geoJSON(data);
+      const bounds = geoJsonLayer.getBounds();
+      // Adjusting the map view and setting limits.
+      map.fitBounds(bounds);
+      map.setMaxBounds(bounds);
+      map.setMinZoom(map.getZoom());
+      // Disabling tap if it's available for better mobile support.
+      if (map.tap) map.tap.disable();
+    }, [data, map]);
+
+    return null;
+  };
+
   return (
-    <MapContainer center={[45.4211, -75.6903]} zoom={4} style={{ height: '600px', width: '100%' }}>
-      <TileLayer
-        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-      />
-      <GeoJSON data={geoJsonData} style={geoJsonStyle} onEachFeature={onEachFeature} />
+    <MapContainer 
+      center={[45.4211, -75.6903]} 
+      zoom={1} 
+      style={{ height: '400px', width: '100vw' }}
+      zoomControl={false}
+      keyboard={false}
+    >
+      {geoJsonData && (
+        <>
+          <GeoJSON data={geoJsonData} style={geoJsonStyle} onEachFeature={onEachFeature} />
+          <FitBounds data={geoJsonData} />
+        </>
+      )}
     </MapContainer>
   );
 };


### PR DESCRIPTION
### Things done:

- Style map.
- Auto-adjust view to GeoJSON in GeoJSONMap.
- Boundary calculation in useEffect using GeoJSON data.
- Set initial settings and dimensions in MapContainer.
- Render GeoJSON layer and FitBounds if geoJsonData exists.
- Disable zoom control and keyboard interaction.
- Mobile compatibility (disable tap when needed).

#### Things to consider:

- Style map further
- Put up a better container.
- Add more map features.