### PR TITLE
Relocate Color Picker for Sidebar Integration

### DIFF
--- a/client/src/components/ColorPickerComponent.tsx
+++ b/client/src/components/ColorPickerComponent.tsx
@@ -41,21 +41,20 @@ const ColorPickerComponent: React.FC<ColorPickerProps> = ({ onColorChange }) => 
   const styles = reactCSS({
     default: {
       swatch: {
-        padding: '5px',
-        background: '#fff',
-        borderRadius: '1px',
-        boxShadow: '0 0 0 1px rgba(0,0,0,.1)',
-        display: 'inline-block',
-        cursor: 'pointer',
+        width: '100%',
+        display: 'block',
       },
       popover: {
-        width: '500px',
-        position: 'absolute' as 'absolute',
-        zIndex: '700',
-        right: '37%',
+        position: 'absolute',
+        zIndex: '2',
+        right: '0%',
+      },
+      sliderContainer: {
+        marginTop: '10px',
       },
       cover: {
         position: 'fixed' as 'fixed',
+        borderRadius: '2px',
       },
     },
   });
@@ -63,10 +62,10 @@ const ColorPickerComponent: React.FC<ColorPickerProps> = ({ onColorChange }) => 
   return (
     <div>
       <div style={styles.swatch} onClick={handleClick}>
-        <div style={{ backgroundColor: color.hex, width: '36px', height: '14px', borderRadius: '2px' }} />
+        <div style={{ backgroundColor: color.hex, width: '28px', height: '24px', borderRadius: '2px' }} />
       </div>
       {displayColorPicker ? (
-        <div style={styles.popover}>
+        <div style={styles.sliderContainer}>
           <div style={styles.cover} onClick={handleClose} />
           <SliderPicker color={color as any} onChange={handleChange} />
         </div>

--- a/client/src/components/geoJSONMap.tsx
+++ b/client/src/components/geoJSONMap.tsx
@@ -3,9 +3,9 @@ import { MapContainer, GeoJSON, useMap } from 'react-leaflet';
 import { GeoJsonObject, Feature, Geometry } from 'geojson';
 import 'leaflet/dist/leaflet.css';
 import L from 'leaflet';
-import ColorPickerComponent from './ColorPickerComponent';
+import { useToggle } from '../contexts/useToggle';
 import { ColorResult, RGBColor } from 'react-color';
-import { generateColorGradient, getColor, extractValuesFromGeoJSON, convertColorToString } from '../utils/colourUtils';
+import { hexToRgb, generateColorGradient, getColor, extractValuesFromGeoJSON, convertColorToString } from '../utils/colourUtils';
 import "./geoJSONMap.css";
 // Defining a custom interface for GeoJSON features with additional properties.
 interface GeoJSONFeature extends Feature<Geometry> {
@@ -18,27 +18,21 @@ interface GeoJSONMapProps {
 }
 
 const GeoJSONMap: React.FC<GeoJSONMapProps> = ({ geoJsonData }) => {
-    const initialColor: RGBColor = { r: 152, g: 175, b: 199 };
     const [mapKey, setMapKey] = useState(Date.now());
     const [colorGradient, setColorGradient] = useState<{ [key: number]: string }>({});
     const [allValues, setValues] = useState<number[]>([]);
     const [steps, setSteps] = useState<number>(5); // State for steps
-    const [color, setColor] = useState(initialColor);
+    const { colorPickerColor} = useToggle();
 
   // Effect to initialize color gradient and data values
   useEffect(() => {
     if (geoJsonData) {
       setValues(extractValuesFromGeoJSON(geoJsonData));
-      setColorGradient(generateColorGradient(steps, convertColorToString(color)));
+      const rgbColor = hexToRgb(colorPickerColor);
+      setColorGradient(generateColorGradient(steps, rgbColor));
     }
-    }, [geoJsonData, color]);
+    }, [geoJsonData, colorPickerColor, steps]);
 
-  const handleColorChange = (colorOrig: ColorResult) => {
-    const newColor = colorOrig.rgb;
-   setColor(newColor);
-   setColorGradient(generateColorGradient(steps, convertColorToString(newColor)));
- };
- 
   const geoJsonStyle = (feature: any) => {
   const currValue = feature.properties.totalSamples as number;
   const fillColorIndex = getColor(currValue, allValues, steps); // Call getColor function to get the fill color
@@ -87,11 +81,6 @@ useEffect(() => {
 
 return (
  <>
-   <ColorPickerComponent
-     onColorChange={(color: ColorResult): void => {
-       handleColorChange(color);
-     }}
-   />
    <MapContainer
      key={mapKey}
      zoom={1}

--- a/client/src/components/sidebar.tsx
+++ b/client/src/components/sidebar.tsx
@@ -1,6 +1,7 @@
 import React, {useState} from "react";
 import "./sidebar.css";
 import { useToggle } from "../contexts/useToggle";
+import ColorPickerComponent from "./ColorPickerComponent";
 
 type FilterGroup = {
     id: string;
@@ -13,6 +14,7 @@ interface SidebarProps {
 
 // mock data
 const mockFilterGroups: FilterGroup[] = [
+	{ id: "1", name: "Color Picker" },
     { id: "3", name: "Select File" },
 	{ id: "4", name: "Download Map" },
 ];
@@ -26,8 +28,8 @@ const Sidebar: React.FC<SidebarProps> = ({handleDownload}) => {
         uploadedFiles,
         setCurrentFileIndex,
         setIsUploadedFileVisible,
-        baseMapColor,
-        setBaseMapColor,
+        colorPickerColor,
+        setColorPickerColor,
         currentFileIndex,
     } = useToggle();
 
@@ -76,11 +78,13 @@ const Sidebar: React.FC<SidebarProps> = ({handleDownload}) => {
 					>
 						<div className="menu-item-checkbox">
 							{group.id === "1" ? (
-								<input
-									type="color"
-									value={baseMapColor}
-									onChange={(e) => setBaseMapColor(e.target.value)}
-								/>
+								<><label
+									htmlFor={`checkbox-${group.id}`}
+									className="menu-item-label"
+								>
+									{group.name}
+								</label><ColorPickerComponent
+										onColorChange={(colorResult) => setColorPickerColor(colorResult.hex)} /></>
 							) : (
 								<>
 									<input

--- a/client/src/contexts/toggleContext.tsx
+++ b/client/src/contexts/toggleContext.tsx
@@ -19,8 +19,8 @@ type ToggleContextType = {
 	setIsUploadedFileVisible: (isVisible: boolean) => void;
 	uploadedFile            : UploadFileData | null;
 	setUploadedFile         : (file: UploadFileData | null) => void;
-	mapColor                : string;
-	setMapColor             : (color: string) => void;
+	colorPickerColor        : string;
+	setColorPickerColor     : (color: string) => void;
 	uploadedFiles           : UploadFileData[];
 	setUploadedFiles        : (files: UploadFileData[]) => void;
 	currentFileIndex        : number;
@@ -35,8 +35,8 @@ const defaultState: ToggleContextType = {
 	setIsUploadedFileVisible: () => {},
 	uploadedFile            : null,
 	setUploadedFile         : () => {},
-	mapColor                : "white",
-	setMapColor             : () => {},
+	colorPickerColor        : "#98AFC7",
+	setColorPickerColor     : () => {},
 	uploadedFiles           : [],
 	setUploadedFiles        : () => {},
 	currentFileIndex        : 0,
@@ -54,7 +54,7 @@ export const ToggleProvider: React.FC = ({ children }) => {
 		defaultState.isUploadedFileVisible
 	);
 	const [uploadedFile, setUploadedFile]   = useState(defaultState.uploadedFile);
-	const [mapColor, setMapColor]           = useState(defaultState.mapColor);
+	const [colorPickerColor, setColorPickerColor]           = useState(defaultState.colorPickerColor);
 	const [uploadedFiles, setUploadedFiles] = useState(
 		defaultState.uploadedFiles
 	);
@@ -110,8 +110,8 @@ export const ToggleProvider: React.FC = ({ children }) => {
 				setIsUploadedFileVisible,
 				uploadedFile,
 				setUploadedFile,
-				mapColor,
-				setMapColor,
+				colorPickerColor,
+				setColorPickerColor,
 				uploadedFiles,
 				setUploadedFiles,
 				currentFileIndex,

--- a/client/src/utils/colourUtils.ts
+++ b/client/src/utils/colourUtils.ts
@@ -79,3 +79,19 @@ export function extractValuesFromGeoJSON(geoJsonData: GeoJsonObject): number[] {
 export function convertColorToString(color: RGBColor): string {
     return `rgb(${color.r}, ${color.g}, ${color.b})`;
 }
+
+export function hexToRgb(hex: string | any[]) {
+    let r = 0, g = 0, b = 0;
+
+    if (hex.length === 4) {
+        r = parseInt(hex[1] + hex[1], 16);
+        g = parseInt(hex[2] + hex[2], 16);
+        b = parseInt(hex[3] + hex[3], 16);
+    }
+    else if (hex.length === 7) {
+        r = parseInt(hex[1] + hex[2], 16);
+        g = parseInt(hex[3] + hex[4], 16);
+        b = parseInt(hex[5] + hex[6], 16);
+    }
+    return `rgb(${r}, ${g}, ${b})`;
+}


### PR DESCRIPTION
### Things done:
- Moved the color picker from under the main map container to the sidebar.
- Color picker's popover style adjusted for sidebar.
- Made changes to how the color picker's information is stored and used through state management in `toggleContext.tsx`.
- Added `hexToRgb` function in `colorUtils.ts` to change color codes to a format needed by other parts of the program.
- Cleaned up code in `toggleContext.tsx` to make sure it works well with how the color picker is now set up.
- Tested everything to make sure the color picker still works well after moving it.
- Adjusted the use of color picker in the `GeoJSONMap.tsx` for setting the gradient, removed `handleColorChange` and `ColorPickerComponent`.

### Things to consider:
- Enhance UI