### PR TITLE
Implemented Region Toggles Feature with Dynamic Bound Fitting

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -138,7 +138,7 @@ const App: React.FC = () => {
 	return (
 		<div className="App noise">
 			<h1> CGC Data Visualization</h1>
-			<Sidebar handleDownload = {handleDownload} />
+			<Sidebar handleDownload = {handleDownload} geoJsonData={mapData}/>
 			{mapData && (
 				<div className="map-frame">
 					<GeoJSONMap geoJsonData={mapData} />

--- a/client/src/components/geoJSONMap.tsx
+++ b/client/src/components/geoJSONMap.tsx
@@ -1,117 +1,141 @@
-import React, { useEffect, useState } from 'react';
-import { MapContainer, GeoJSON, useMap } from 'react-leaflet';
-import { GeoJsonObject, Feature, Geometry } from 'geojson';
-import 'leaflet/dist/leaflet.css';
-import L from 'leaflet';
-import { useToggle } from '../contexts/useToggle';
-import { ColorResult, RGBColor } from 'react-color';
-import { hexToRgb, generateColorGradient, getColor, extractValuesFromGeoJSON, convertColorToString } from '../utils/colourUtils';
+import React, { useEffect, useState } from "react";
+import { MapContainer, GeoJSON, useMap } from "react-leaflet";
+import { GeoJsonObject, Feature, Geometry } from "geojson";
+import "leaflet/dist/leaflet.css";
+import L from "leaflet";
+import { useToggle } from "../contexts/useToggle";
+import { ColorResult, RGBColor } from "react-color";
+import {
+    hexToRgb,
+    generateColorGradient,
+    getColor,
+    extractValuesFromGeoJSON,
+    convertColorToString,
+} from "../utils/colourUtils";
 import "./geoJSONMap.css";
 // Defining a custom interface for GeoJSON features with additional properties.
 interface GeoJSONFeature extends Feature<Geometry> {
-  properties: { [key: string]: unknown };
+    properties: { [key: string]: unknown };
 }
 
 // Props for our GeoJSONMap component, expecting geoJsonData.
 interface GeoJSONMapProps {
-  geoJsonData: GeoJsonObject | null;
+    geoJsonData: GeoJsonObject | null;
 }
 
 const GeoJSONMap: React.FC<GeoJSONMapProps> = ({ geoJsonData }) => {
     const [mapKey, setMapKey] = useState(Date.now());
-    const [colorGradient, setColorGradient] = useState<{ [key: number]: string }>({});
+    const [colorGradient, setColorGradient] = useState<{
+        [key: number]: string;
+    }>({});
     const [allValues, setValues] = useState<number[]>([]);
     const [steps, setSteps] = useState<number>(5); // State for steps
-    const { colorPickerColor, featureVisibility} = useToggle();
+    const { colorPickerColor, featureVisibility } = useToggle();
 
-  // Effect to initialize color gradient and data values
-  useEffect(() => {
-    if (geoJsonData) {
-      setValues(extractValuesFromGeoJSON(geoJsonData));
-      const rgbColor = hexToRgb(colorPickerColor);
-      setColorGradient(generateColorGradient(steps, rgbColor));
-    }
+    // Effect to initialize color gradient and data values
+    useEffect(() => {
+        if (geoJsonData) {
+            setValues(extractValuesFromGeoJSON(geoJsonData));
+            const rgbColor = hexToRgb(colorPickerColor);
+            setColorGradient(generateColorGradient(steps, rgbColor));
+        }
     }, [geoJsonData, colorPickerColor, steps]);
 
     const defaultStyle = {
-      fillColor: '#98AFC7',
-      weight: 1,
-      color: 'white',
-      fillOpacity: 0.5,
+        fillColor: "#98AFC7",
+        weight: 1,
+        color: "white",
+        fillOpacity: 0.5,
     };
 
-  const geoJsonStyle = (feature: any) => {
-  const currValue = feature.properties.totalSamples as number;
-  const fillColorIndex = getColor(currValue, allValues, steps); // Call getColor function to get the fill color
-  if (!featureVisibility[feature.properties.CARUID]) {
-    return { fillOpacity: 0, weight: 0, color: 'white', fillColor: 'gray' };
-  }
+    const geoJsonStyle = (feature: any) => {
+        const currValue = feature.properties.totalSamples as number;
+        const fillColorIndex = getColor(currValue, allValues, steps); // Call getColor function to get the fill color
+        if (!featureVisibility[feature.properties.CARUID]) {
+            return {
+                fillOpacity: 0,
+                weight: 0,
+                color: "white",
+                fillColor: "gray",
+            };
+        }
 
-  return {
-    fillColor: colorGradient[fillColorIndex] || 'gray',
-    weight: 1,
-    color: 'white',
-    fillOpacity: 0.5,
-  };
-};
+        return {
+            fillColor: colorGradient[fillColorIndex] || "gray",
+            weight: 1,
+            color: "white",
+            fillOpacity: 0.5,
+        };
+    };
 
-  // A component to automatically adjust the map view to fit all our GeoJSON features.
-  
-   const onEachFeature = (feature: GeoJSONFeature, layer: L.Layer) => {
-       if (feature.properties) {
-           layer.bindPopup(
-               Object.keys(feature.properties)
-                   .map(
-                       (key) =>
-                           `<strong>${key}</strong>: ${feature.properties[key]}`
-                   )
-                   .join("<br />")
-           );
-       }
-   };
+    // A component to automatically adjust the map view to fit all our GeoJSON features.
 
-const FitBounds = ({ data }: { data: GeoJsonObject }) => {
-   const map = useMap();
+    const onEachFeature = (feature: GeoJSONFeature, layer: L.Layer) => {
+        if (feature.properties) {
+            layer.bindPopup(
+                Object.keys(feature.properties)
+                    .map(
+                        (key) =>
+                            `<strong>${key}</strong>: ${feature.properties[key]}`
+                    )
+                    .join("<br />")
+            );
+        }
+    };
 
-   useEffect(() => {
-       const geoJsonLayer = L.geoJSON(data);
-       const bounds = geoJsonLayer.getBounds();
-       map.fitBounds(bounds);
-       map.setMaxBounds(bounds);
-       map.setMinZoom(map.getZoom());
-       if (map.tap) map.tap.disable();
-   }, [data, map]);
+    const FitBounds = ({ data }: { data: GeoJsonObject }) => {
+        const map = useMap();
 
-   return null;
-};
+        useEffect(() => {
+            if (data && "features" in data) {
+                const visibleFeatures = data.features.filter(
+                    (feature) =>
+                        feature.properties &&
+                        featureVisibility[feature.properties.CARUID]
+                );
+                const geoJsonLayer = L.geoJSON(
+                    visibleFeatures as GeoJsonObject
+                );
+                const bounds = geoJsonLayer.getBounds();
+                if (bounds.isValid()) {
+                    map.fitBounds(bounds);
+                    map.setMaxBounds(bounds);
+                    map.setMinZoom(map.getZoom());
+                }
+            }
+            if (map.tap) map.tap.disable();
+        }, [data, map, featureVisibility]);
 
-useEffect(() => {
-   setMapKey(Date.now());
-}, [geoJsonData]);
+        return null;
+    };
 
-return (
- <>
-   <MapContainer
-     key={mapKey}
-     zoom={1}
-     zoomControl={true}
-     keyboard={false}
-     preferCanvas={false}
-     inertia={false}
-   >
-     {geoJsonData && (
-       <>
-         <GeoJSON
-           data={geoJsonData}
-           style={geoJsonStyle}
-           onEachFeature={onEachFeature}
-         />
-         <FitBounds data={geoJsonData} />
-       </>
-     )}
-   </MapContainer>
- </>
-);
+    useEffect(() => {
+        setMapKey(Date.now());
+    }, [geoJsonData]);
+
+    return (
+        <>
+            <MapContainer
+                key={mapKey}
+                zoom={1}
+                zoomControl={true}
+                keyboard={false}
+                preferCanvas={false}
+                inertia={false}
+            >
+                {geoJsonData && (
+                    <>
+                        <GeoJSON
+                            data={geoJsonData}
+                            style={geoJsonStyle}
+                            onEachFeature={onEachFeature}
+                        />
+                        <FitBounds data={geoJsonData} />
+                    </>
+                )}
+            </MapContainer>
+        </>
+    );
 };
 
 export default GeoJSONMap;

--- a/client/src/components/geoJSONMap.tsx
+++ b/client/src/components/geoJSONMap.tsx
@@ -56,15 +56,15 @@ const GeoJSONMap: React.FC<GeoJSONMapProps> = ({ geoJsonData }) => {
                 fillOpacity: 0,
                 weight: 0,
                 color: "white",
-                fillColor: "gray",
+                fillColor: colorGradient[fillColorIndex],
             };
         }
 
         return {
-            fillColor: colorGradient[fillColorIndex] || "gray",
-            weight: 1,
-            color: "white",
-            fillOpacity: 0.5,
+            fillColor: colorGradient[fillColorIndex] || "white",
+            weight: 0.7,
+            color: "black",
+            fillOpacity: 1,
         };
     };
 
@@ -117,7 +117,7 @@ const GeoJSONMap: React.FC<GeoJSONMapProps> = ({ geoJsonData }) => {
         <>
             <MapContainer
                 key={mapKey}
-                zoom={0}
+                zoom={1}
                 zoomControl={true}
                 keyboard={false}
                 preferCanvas={false}

--- a/client/src/components/geoJSONMap.tsx
+++ b/client/src/components/geoJSONMap.tsx
@@ -22,7 +22,7 @@ const GeoJSONMap: React.FC<GeoJSONMapProps> = ({ geoJsonData }) => {
     const [colorGradient, setColorGradient] = useState<{ [key: number]: string }>({});
     const [allValues, setValues] = useState<number[]>([]);
     const [steps, setSteps] = useState<number>(5); // State for steps
-    const { colorPickerColor} = useToggle();
+    const { colorPickerColor, featureVisibility} = useToggle();
 
   // Effect to initialize color gradient and data values
   useEffect(() => {
@@ -33,17 +33,27 @@ const GeoJSONMap: React.FC<GeoJSONMapProps> = ({ geoJsonData }) => {
     }
     }, [geoJsonData, colorPickerColor, steps]);
 
+    const defaultStyle = {
+      fillColor: '#98AFC7',
+      weight: 1,
+      color: 'white',
+      fillOpacity: 0.5,
+    };
+
   const geoJsonStyle = (feature: any) => {
   const currValue = feature.properties.totalSamples as number;
   const fillColorIndex = getColor(currValue, allValues, steps); // Call getColor function to get the fill color
+  if (!featureVisibility[feature.properties.CARUID]) {
+    return { fillOpacity: 0, weight: 0, color: 'white', fillColor: 'gray' };
+  }
 
   return {
     fillColor: colorGradient[fillColorIndex] || 'gray',
     weight: 1,
     color: 'white',
     fillOpacity: 0.5,
-   };
- };
+  };
+};
 
   // A component to automatically adjust the map view to fit all our GeoJSON features.
   

--- a/client/src/components/geoJSONMap.tsx
+++ b/client/src/components/geoJSONMap.tsx
@@ -100,7 +100,7 @@ const GeoJSONMap: React.FC<GeoJSONMapProps> = ({ geoJsonData }) => {
                 if (bounds.isValid()) {
                     map.fitBounds(bounds);
                     map.setMaxBounds(bounds);
-                    map.setMinZoom(map.getZoom());
+                    map.setMinZoom(1);
                 }
             }
             if (map.tap) map.tap.disable();
@@ -117,7 +117,7 @@ const GeoJSONMap: React.FC<GeoJSONMapProps> = ({ geoJsonData }) => {
         <>
             <MapContainer
                 key={mapKey}
-                zoom={1}
+                zoom={0}
                 zoomControl={true}
                 keyboard={false}
                 preferCanvas={false}

--- a/client/src/components/sidebar.tsx
+++ b/client/src/components/sidebar.tsx
@@ -72,7 +72,14 @@ const Sidebar: React.FC<SidebarProps> = ({handleDownload, geoJsonData}) => {
 	const renderFeatureVisibilityToggles = () => {
         if (!geoJsonData || !geoJsonData.features) return null;
 
-        return geoJsonData.features.map((feature, index) => {
+		const sortedFeatures = geoJsonData.features.sort((curr, prev) => {
+            const currKey = curr.properties?.CARUID || "";
+            const prevKey = prev.properties?.CARUID || "";
+            if (!currKey || !prevKey) return 0;
+            return currKey.localeCompare(prevKey);
+        });
+
+        return sortedFeatures.map((feature, index) => {
             const key = feature.properties?.CARUID;
             if (!key) return null;
 

--- a/client/src/contexts/toggleContext.tsx
+++ b/client/src/contexts/toggleContext.tsx
@@ -26,6 +26,9 @@ type ToggleContextType = {
 	currentFileIndex        : number;
 	setCurrentFileIndex     : (index: number) => void;
 	fetchUploadedFiles      : FetchUploadedFilesFunction;
+	featureVisibility	    : {[key: string]: boolean};
+	toggleFeatureVisibility : (feature: string) => void;
+	setFeatureVisibility    : (visibility: {[key: string]: boolean}) => void;
 	removeUploadedFile		: (index: number) => void;
 };
 
@@ -44,6 +47,9 @@ const defaultState: ToggleContextType = {
 	setCurrentFileIndex     : () => {},
 	fetchUploadedFiles      : async () => [],
 	removeUploadedFile		: () => {},
+	featureVisibility       : {},
+	toggleFeatureVisibility : () => {},
+	setFeatureVisibility    : () => {},
 };
 
 export const ToggleContext = createContext<ToggleContextType>(defaultState);
@@ -64,6 +70,17 @@ export const ToggleProvider: React.FC = ({ children }) => {
 		defaultState.currentFileIndex
 	);
 	const [removedFileIds, setRemovedFileIds] = useState<string[]>([]);
+
+	const [featureVisibility, setFeatureVisibility] = useState<{
+		[key: string]: boolean;
+	}>(defaultState.featureVisibility);
+
+	const toggleFeatureVisibility = (key: string) => {
+		setFeatureVisibility((prev) => ({
+			...prev,
+			[key]: !prev[key],
+		}));
+	};
 	
 	useEffect(() => {
         const storedRemovedFileIds = localStorage.getItem("removedFileIds");
@@ -148,6 +165,9 @@ export const ToggleProvider: React.FC = ({ children }) => {
 				currentFileIndex,
 				setCurrentFileIndex,
 				fetchUploadedFiles,
+				featureVisibility,
+				toggleFeatureVisibility,
+				setFeatureVisibility,
 				removeUploadedFile,
 			}}
 		>


### PR DESCRIPTION
### Things done:
- Passed map data to sidebar
- Added visibility states for regions
- Sidebar now renders all the crop regions with toggles for visibility
- The toggles operate in real time 
- Sidebar shows all the regions in a sorted manner (by crop region id number)
- Initially all the regions are selected true (works with base map as well)
- `geoJsonMap` uses `toggleContext` for crop region visibility 
- Toggling each crop region renders it either visible or not visible 
-  The map dynamically fits bound when regions according to region visibility 
- Fit bounds now properly zooms in and out after each toggle
- Fixed map color contrast, borders and zoom levels

### Thing to consider:
- Adjust sidebar menu item placements