### PR TITLE
Update colour picker

### DIFF
--- a/client/src/components/ColorPickerComponent.tsx
+++ b/client/src/components/ColorPickerComponent.tsx
@@ -8,7 +8,7 @@ interface ColorPickerProps {
 }
 
 const ColorPickerComponent: React.FC<ColorPickerProps> = ({ onColorChange, backgroundColor}) => {
-  const [displayColorPicker, setDisplayColorPicker] = useState(false);
+  const [displayColorPicker, setDisplayColorPicker] = useState(true);
   const [color, setColor] = useState<ColorResult>({
     hex: '#755b73',
     rgb: {
@@ -61,7 +61,7 @@ const ColorPickerComponent: React.FC<ColorPickerProps> = ({ onColorChange, backg
   });
 
   return (
-    <div>
+    <div className='color-picker-container'>
       <div style={styles.swatch} onClick={handleClick}>
         <div style={{ backgroundColor: backgroundColor, width: '28px', height: '24px', borderRadius: '2px' }} />
       </div>

--- a/client/src/components/ColorPickerComponent.tsx
+++ b/client/src/components/ColorPickerComponent.tsx
@@ -4,12 +4,13 @@ import { SliderPicker, ColorResult } from 'react-color';
 
 interface ColorPickerProps {
   onColorChange: (color: ColorResult) => void;
+  backgroundColor: string;
 }
 
-const ColorPickerComponent: React.FC<ColorPickerProps> = ({ onColorChange }) => {
+const ColorPickerComponent: React.FC<ColorPickerProps> = ({ onColorChange, backgroundColor}) => {
   const [displayColorPicker, setDisplayColorPicker] = useState(false);
   const [color, setColor] = useState<ColorResult>({
-    hex: '#98afc7',
+    hex: '#755b73',
     rgb: {
       r: 152,
       g: 175,
@@ -62,12 +63,12 @@ const ColorPickerComponent: React.FC<ColorPickerProps> = ({ onColorChange }) => 
   return (
     <div>
       <div style={styles.swatch} onClick={handleClick}>
-        <div style={{ backgroundColor: color.hex, width: '28px', height: '24px', borderRadius: '2px' }} />
+        <div style={{ backgroundColor: backgroundColor, width: '28px', height: '24px', borderRadius: '2px' }} />
       </div>
       {displayColorPicker ? (
         <div style={styles.sliderContainer}>
           <div style={styles.cover} onClick={handleClose} />
-          <SliderPicker color={color as any} onChange={handleChange} />
+          <SliderPicker color={backgroundColor} onChange={handleChange} />
         </div>
       ) : null}
     </div>

--- a/client/src/components/ColorPickerComponent.tsx
+++ b/client/src/components/ColorPickerComponent.tsx
@@ -1,6 +1,7 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import reactCSS from 'reactcss';
 import { SliderPicker, ColorResult } from 'react-color';
+import { useToggle } from '../contexts/useToggle';
 
 interface ColorPickerProps {
   onColorChange: (color: ColorResult) => void;
@@ -8,6 +9,7 @@ interface ColorPickerProps {
 }
 
 const ColorPickerComponent: React.FC<ColorPickerProps> = ({ onColorChange, backgroundColor}) => {
+  const { autoColourRange } = useToggle();
   const [displayColorPicker, setDisplayColorPicker] = useState(true);
   const [color, setColor] = useState<ColorResult>({
     hex: '#755b73',
@@ -59,6 +61,10 @@ const ColorPickerComponent: React.FC<ColorPickerProps> = ({ onColorChange, backg
       },
     },
   });
+
+  useEffect(() => {
+    setDisplayColorPicker(true);
+  }, [autoColourRange]);
 
   return (
     <div className='color-picker-container'>

--- a/client/src/components/geoJSONMap.tsx
+++ b/client/src/components/geoJSONMap.tsx
@@ -30,16 +30,17 @@ const GeoJSONMap: React.FC<GeoJSONMapProps> = ({ geoJsonData }) => {
     }>({});
     const [allValues, setValues] = useState<number[]>([]);
     const [steps, setSteps] = useState<number>(5); // State for steps
-    const { colorPickerColor, featureVisibility } = useToggle();
+    const {colorPickerColor, colorPickerColor_2, featureVisibility} = useToggle();
 
     // Effect to initialize color gradient and data values
     useEffect(() => {
         if (geoJsonData) {
             setValues(extractValuesFromGeoJSON(geoJsonData));
             const rgbColor = hexToRgb(colorPickerColor);
-            setColorGradient(generateColorGradient(steps, rgbColor));
+            const rgbColor_2 = hexToRgb(colorPickerColor_2);
+            setColorGradient(generateColorGradient(steps, rgbColor, rgbColor_2));
         }
-    }, [geoJsonData, colorPickerColor, steps]);
+    }, [geoJsonData, colorPickerColor, colorPickerColor_2, steps]);
 
     const defaultStyle = {
         fillColor: "#98AFC7",

--- a/client/src/components/geoJSONMap.tsx
+++ b/client/src/components/geoJSONMap.tsx
@@ -36,9 +36,9 @@ const GeoJSONMap: React.FC<GeoJSONMapProps> = ({ geoJsonData }) => {
     useEffect(() => {
         if (geoJsonData) {
             setValues(extractValuesFromGeoJSON(geoJsonData));
-            const rgbColor = hexToRgb(primaryColorPicker);
-            const rgbColor_2 = hexToRgb(secondaryColorPicker);
-            setColorGradient(generateColorGradient(steps, rgbColor, rgbColor_2, autoColourRange));
+            const primaryRGB = hexToRgb(primaryColorPicker);
+            const secondaryRGB = hexToRgb(secondaryColorPicker);
+            setColorGradient(generateColorGradient(steps, primaryRGB, secondaryRGB, autoColourRange));
         }
     }, [geoJsonData, primaryColorPicker, secondaryColorPicker, autoColourRange, steps]);
 

--- a/client/src/components/geoJSONMap.tsx
+++ b/client/src/components/geoJSONMap.tsx
@@ -30,7 +30,7 @@ const GeoJSONMap: React.FC<GeoJSONMapProps> = ({ geoJsonData }) => {
     }>({});
     const [allValues, setValues] = useState<number[]>([]);
     const [steps, setSteps] = useState<number>(5); // State for steps
-    const {colorPickerColor, colorPickerColor_2, featureVisibility} = useToggle();
+    const {primaryColorPicker, secondaryColorPicker, featureVisibility} = useToggle();
 
     // Effect to initialize color gradient and data values
     useEffect(() => {

--- a/client/src/components/geoJSONMap.tsx
+++ b/client/src/components/geoJSONMap.tsx
@@ -30,7 +30,7 @@ const GeoJSONMap: React.FC<GeoJSONMapProps> = ({ geoJsonData }) => {
     }>({});
     const [allValues, setValues] = useState<number[]>([]);
     const [steps, setSteps] = useState<number>(5); // State for steps
-    const {primaryColorPicker, secondaryColorPicker, featureVisibility, isMonochromeMap} = useToggle();
+    const {primaryColorPicker, secondaryColorPicker, featureVisibility, autoColourRange} = useToggle();
 
     // Effect to initialize color gradient and data values
     useEffect(() => {
@@ -38,9 +38,9 @@ const GeoJSONMap: React.FC<GeoJSONMapProps> = ({ geoJsonData }) => {
             setValues(extractValuesFromGeoJSON(geoJsonData));
             const rgbColor = hexToRgb(primaryColorPicker);
             const rgbColor_2 = hexToRgb(secondaryColorPicker);
-            setColorGradient(generateColorGradient(steps, rgbColor, rgbColor_2, isMonochromeMap));
+            setColorGradient(generateColorGradient(steps, rgbColor, rgbColor_2, autoColourRange));
         }
-    }, [geoJsonData, primaryColorPicker, secondaryColorPicker, isMonochromeMap, steps]);
+    }, [geoJsonData, primaryColorPicker, secondaryColorPicker, autoColourRange, steps]);
 
     const defaultStyle = {
         fillColor: "#98AFC7",

--- a/client/src/components/geoJSONMap.tsx
+++ b/client/src/components/geoJSONMap.tsx
@@ -36,11 +36,11 @@ const GeoJSONMap: React.FC<GeoJSONMapProps> = ({ geoJsonData }) => {
     useEffect(() => {
         if (geoJsonData) {
             setValues(extractValuesFromGeoJSON(geoJsonData));
-            const rgbColor = hexToRgb(colorPickerColor);
-            const rgbColor_2 = hexToRgb(colorPickerColor_2);
+            const rgbColor = hexToRgb(primaryColorPicker);
+            const rgbColor_2 = hexToRgb(secondaryColorPicker);
             setColorGradient(generateColorGradient(steps, rgbColor, rgbColor_2));
         }
-    }, [geoJsonData, colorPickerColor, colorPickerColor_2, steps]);
+    }, [geoJsonData, primaryColorPicker, secondaryColorPicker, steps]);
 
     const defaultStyle = {
         fillColor: "#98AFC7",

--- a/client/src/components/geoJSONMap.tsx
+++ b/client/src/components/geoJSONMap.tsx
@@ -30,7 +30,7 @@ const GeoJSONMap: React.FC<GeoJSONMapProps> = ({ geoJsonData }) => {
     }>({});
     const [allValues, setValues] = useState<number[]>([]);
     const [steps, setSteps] = useState<number>(5); // State for steps
-    const {primaryColorPicker, secondaryColorPicker, featureVisibility} = useToggle();
+    const {primaryColorPicker, secondaryColorPicker, featureVisibility, isMonochromeMap} = useToggle();
 
     // Effect to initialize color gradient and data values
     useEffect(() => {
@@ -38,9 +38,9 @@ const GeoJSONMap: React.FC<GeoJSONMapProps> = ({ geoJsonData }) => {
             setValues(extractValuesFromGeoJSON(geoJsonData));
             const rgbColor = hexToRgb(primaryColorPicker);
             const rgbColor_2 = hexToRgb(secondaryColorPicker);
-            setColorGradient(generateColorGradient(steps, rgbColor, rgbColor_2));
+            setColorGradient(generateColorGradient(steps, rgbColor, rgbColor_2, isMonochromeMap));
         }
-    }, [geoJsonData, primaryColorPicker, secondaryColorPicker, steps]);
+    }, [geoJsonData, primaryColorPicker, secondaryColorPicker, isMonochromeMap, steps]);
 
     const defaultStyle = {
         fillColor: "#98AFC7",

--- a/client/src/components/sidebar.css
+++ b/client/src/components/sidebar.css
@@ -75,6 +75,7 @@
 .file-item-checkbox input[type="checkbox"] {
     display: none;
 }
+
 .file-item-checkbox input[type="checkbox"] + label:before {
     content: "";
     display: inline-block;
@@ -147,12 +148,22 @@
     opacity: 0.9;
 }
 
+.color-picker-container {
+    margin: 20px;
+}
+
+.color-picker-wrapper {
+    display: flex;
+    flex-direction: column; /* Display sliders below one another */
+}
+
 /* Disable hover effects on children when confirmation dialog is visible */
 .sidebar-menu-dialog-open{
     pointer-events: none;
     cursor: pointer;
     background-color: #f4f6f9;
 }
+
 .sidebar-title {
     display: flex;
     align-items: justify;

--- a/client/src/components/sidebar.css
+++ b/client/src/components/sidebar.css
@@ -130,7 +130,7 @@
     cursor: pointer;
 }
 
-.toggle-button {
+.color-range-toggle-button {
     margin: 8px auto;
     padding: 8px 12px;
     width: 17vw;

--- a/client/src/components/sidebar.css
+++ b/client/src/components/sidebar.css
@@ -142,10 +142,13 @@
     display: flex;
     justify-content: center;
     align-items: center;
+    transition: 0.3s;
 }
 
 .toggle-button:hover {
-    opacity: 0.9;
+    background-color: #9ea2a5;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+    color: #fff;
 }
 
 .color-picker-container {

--- a/client/src/components/sidebar.css
+++ b/client/src/components/sidebar.css
@@ -129,6 +129,24 @@
     cursor: pointer;
 }
 
+.toggle-button {
+    margin: 8px auto;
+    padding: 8px 12px;
+    width: 17vw;
+    background-color: #656667;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.toggle-button:hover {
+    opacity: 0.9;
+}
+
 /* Disable hover effects on children when confirmation dialog is visible */
 .sidebar-menu-dialog-open{
     pointer-events: none;

--- a/client/src/components/sidebar.css
+++ b/client/src/components/sidebar.css
@@ -133,7 +133,7 @@
 .color-range-toggle-button {
     margin: 8px auto;
     padding: 8px 12px;
-    width: 17vw;
+    width: 100%;
     background-color: #656667;
     color: #fff;
     border: none;
@@ -145,7 +145,7 @@
     transition: 0.3s;
 }
 
-.toggle-button:hover {
+.color-range-toggle-button:hover {
     background-color: #9ea2a5;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
     color: #fff;

--- a/client/src/components/sidebar.tsx
+++ b/client/src/components/sidebar.tsx
@@ -185,7 +185,7 @@ const Sidebar: React.FC<SidebarProps> = ({handleDownload, geoJsonData}) => {
 											{group.name}
 										</label>
 										<button
-											className="toggle-button"
+											className="color-range-toggle-button"
 											onClick={() => {
 												handleColorMethodSwitch();
 											}}

--- a/client/src/components/sidebar.tsx
+++ b/client/src/components/sidebar.tsx
@@ -51,7 +51,6 @@ const Sidebar: React.FC<SidebarProps> = ({handleDownload, geoJsonData}) => {
     const handleCardClick = (id: string) => {
 		switch (id) {
 			case "1":
-				console.log("click");
 				break;
 			case "2":
 				setIsTileLayerVisible(!isTileLayerVisible);

--- a/client/src/components/sidebar.tsx
+++ b/client/src/components/sidebar.tsx
@@ -30,7 +30,9 @@ const Sidebar: React.FC<SidebarProps> = ({handleDownload, geoJsonData}) => {
         setIsTileLayerVisible,
         uploadedFiles,
         setCurrentFileIndex,
+		primaryColorPicker,
         setPrimaryColorPicker,
+		secondaryColorPicker,
         setSecondaryColorPicker,
 		isMonochromeMap,
 		setIsMonochromeMap,
@@ -161,11 +163,6 @@ const Sidebar: React.FC<SidebarProps> = ({handleDownload, geoJsonData}) => {
 
 	const handleColorMethodSwitch = () => {
 		setIsMonochromeMap(!isMonochromeMap);
-		if(isMonochromeMap){
-			setSecondaryColorPicker('null');
-		} else {
-			setSecondaryColorPicker('#98afc7');
-		}
 	};
 	
     return (
@@ -189,6 +186,7 @@ const Sidebar: React.FC<SidebarProps> = ({handleDownload, geoJsonData}) => {
 										</label>
 										<ColorPickerComponent
 											onColorChange={(colorResult) => setPrimaryColorPicker(colorResult.hex)}
+											backgroundColor = {primaryColorPicker}
 										/>
 										<button
 											className="toggle-button"
@@ -196,15 +194,16 @@ const Sidebar: React.FC<SidebarProps> = ({handleDownload, geoJsonData}) => {
 												handleColorMethodSwitch();
 											}}
 										>
-											{!isMonochromeMap ? "Switch to Dual-color Map" : "Switch to Monochrome Map"}
+											{isMonochromeMap ? "Switch to Dual-color Map" : "Switch to Monochrome Map"}
 										</button>
-										{isMonochromeMap && (
+										{!isMonochromeMap && (
 											<div>
 												<label className="menu-item-label">
 													{group.name}
 												</label>
 												<ColorPickerComponent
 													onColorChange={(colorResult) => setSecondaryColorPicker(colorResult.hex)}
+													backgroundColor = {secondaryColorPicker}
 												/>
 											</div>
 										)}

--- a/client/src/components/sidebar.tsx
+++ b/client/src/components/sidebar.tsx
@@ -30,8 +30,8 @@ const Sidebar: React.FC<SidebarProps> = ({handleDownload, geoJsonData}) => {
         setIsTileLayerVisible,
         uploadedFiles,
         setCurrentFileIndex,
-        setColorPickerColor,
-        setColorPickerColor_2,
+        setPrimaryColorPicker,
+        setSecondaryColorPicker,
 		isMonochromeMap,
 		setIsMonochromeMap,
         currentFileIndex,
@@ -162,7 +162,9 @@ const Sidebar: React.FC<SidebarProps> = ({handleDownload, geoJsonData}) => {
 	const handleColorMethodSwitch = () => {
 		setIsMonochromeMap(!isMonochromeMap);
 		if(isMonochromeMap){
-			setColorPickerColor_2('null');
+			setSecondaryColorPicker('null');
+		} else {
+			setSecondaryColorPicker('#98afc7');
 		}
 	};
 	
@@ -186,7 +188,7 @@ const Sidebar: React.FC<SidebarProps> = ({handleDownload, geoJsonData}) => {
 											{group.name}
 										</label>
 										<ColorPickerComponent
-											onColorChange={(colorResult) => setColorPickerColor(colorResult.hex)}
+											onColorChange={(colorResult) => setPrimaryColorPicker(colorResult.hex)}
 										/>
 										<button
 											className="toggle-button"
@@ -202,7 +204,7 @@ const Sidebar: React.FC<SidebarProps> = ({handleDownload, geoJsonData}) => {
 													{group.name}
 												</label>
 												<ColorPickerComponent
-													onColorChange={(colorResult) => setColorPickerColor_2(colorResult.hex)}
+													onColorChange={(colorResult) => setSecondaryColorPicker(colorResult.hex)}
 												/>
 											</div>
 										)}

--- a/client/src/components/sidebar.tsx
+++ b/client/src/components/sidebar.tsx
@@ -31,6 +31,9 @@ const Sidebar: React.FC<SidebarProps> = ({handleDownload, geoJsonData}) => {
         uploadedFiles,
         setCurrentFileIndex,
         setColorPickerColor,
+        setColorPickerColor_2,
+		isMonochromeMap,
+		setIsMonochromeMap,
         currentFileIndex,
 		featureVisibility,
         toggleFeatureVisibility,
@@ -155,6 +158,13 @@ const Sidebar: React.FC<SidebarProps> = ({handleDownload, geoJsonData}) => {
 		setFileToDeleteIndex(null);
 		setShowConfirmation(false);
 	};
+
+	const handleColorMethodSwitch = () => {
+		setIsMonochromeMap(!isMonochromeMap);
+		if(isMonochromeMap){
+			setColorPickerColor_2('null');
+		}
+	};
 	
     return (
 		<div className="sidebar">
@@ -170,24 +180,42 @@ const Sidebar: React.FC<SidebarProps> = ({handleDownload, geoJsonData}) => {
 					>
 						<div className="menu-item-checkbox">
 							{group.id === "1" ? (
-								<><label
-									htmlFor={`checkbox-${group.id}`}
-									className="menu-item-label"
-								>
-									{group.name}
-								</label><ColorPickerComponent
-										onColorChange={(colorResult) => setColorPickerColor(colorResult.hex)} /></>
+								<>
+									<>
+										<label htmlFor={`checkbox-${group.id}`} className="menu-item-label">
+											{group.name}
+										</label>
+										<ColorPickerComponent
+											onColorChange={(colorResult) => setColorPickerColor(colorResult.hex)}
+										/>
+										<button
+											className="toggle-button"
+											onClick={() => {
+												handleColorMethodSwitch();
+											}}
+										>
+											{!isMonochromeMap ? "Switch to Dual-color Map" : "Switch to Monochrome Map"}
+										</button>
+										{isMonochromeMap && (
+											<div>
+												<label htmlFor={`checkbox-${group.id}`} className="menu-item-label">
+													{group.name}
+												</label>
+												<ColorPickerComponent
+													onColorChange={(colorResult) => setColorPickerColor_2(colorResult.hex)}
+												/>
+											</div>
+										)}
+									</>
+								</>
 							) : (
 								<>
-									<label
-										htmlFor={`checkbox-${group.id}`}
-										className="menu-item-label"
-									>
+									<label htmlFor={`checkbox-${group.id}`} className="menu-item-label">
 										{group.name}
 									</label>
 								</>
 							)}
-						</div>
+					</div>
 						{group.id === "3" && showFileList && (
 							<ul className="file-dropdown">
 								{uploadedFiles.map((file, index) => (

--- a/client/src/components/sidebar.tsx
+++ b/client/src/components/sidebar.tsx
@@ -34,8 +34,8 @@ const Sidebar: React.FC<SidebarProps> = ({handleDownload, geoJsonData}) => {
         setPrimaryColorPicker,
 		secondaryColorPicker,
         setSecondaryColorPicker,
-		isMonochromeMap,
-		setIsMonochromeMap,
+		autoColourRange,
+		setAutoColourRange,
         currentFileIndex,
 		featureVisibility,
         toggleFeatureVisibility,
@@ -162,7 +162,7 @@ const Sidebar: React.FC<SidebarProps> = ({handleDownload, geoJsonData}) => {
 	};
 
 	const handleColorMethodSwitch = () => {
-		setIsMonochromeMap(!isMonochromeMap);
+		setAutoColourRange(!autoColourRange);
 	};
 	
     return (
@@ -194,9 +194,9 @@ const Sidebar: React.FC<SidebarProps> = ({handleDownload, geoJsonData}) => {
 												handleColorMethodSwitch();
 											}}
 										>
-											{isMonochromeMap ? "Switch to Dual-color Map" : "Switch to Monochrome Map"}
+											{autoColourRange ? "Auto-Color Range":"Manual Color Range"}
 										</button>
-										{!isMonochromeMap && (
+										{!autoColourRange && (
 											<div>
 												<label className="menu-item-label">
 													{group.name}

--- a/client/src/components/sidebar.tsx
+++ b/client/src/components/sidebar.tsx
@@ -17,7 +17,7 @@ interface SidebarProps {
 
 // mock data
 const mockFilterGroups: FilterGroup[] = [
-	{ id: "1", name: "Color Picker" },
+	{ id: "1", name: "Map Colors" },
     { id: "3", name: "Select File" },
 	{ id: "4", name: "Select Crop Region" },
 	{ id: "5", name: "Download Map" },
@@ -51,6 +51,7 @@ const Sidebar: React.FC<SidebarProps> = ({handleDownload, geoJsonData}) => {
     const handleCardClick = (id: string) => {
 		switch (id) {
 			case "1":
+				console.log("click");
 				break;
 			case "2":
 				setIsTileLayerVisible(!isTileLayerVisible);
@@ -184,29 +185,26 @@ const Sidebar: React.FC<SidebarProps> = ({handleDownload, geoJsonData}) => {
 										<label className="menu-item-label">
 											{group.name}
 										</label>
-										<ColorPickerComponent
-											onColorChange={(colorResult) => setPrimaryColorPicker(colorResult.hex)}
-											backgroundColor = {primaryColorPicker}
-										/>
 										<button
 											className="toggle-button"
 											onClick={() => {
 												handleColorMethodSwitch();
 											}}
 										>
-											{autoColourRange ? "Auto-Color Range":"Manual Color Range"}
+											{!autoColourRange ? "Auto-Color Range":"Manual Color Range"}
 										</button>
-										{!autoColourRange && (
-											<div>
-												<label className="menu-item-label">
-													{group.name}
-												</label>
+										<div className="color-picker-wrapper">
+											<ColorPickerComponent
+												onColorChange={(colorResult) => setPrimaryColorPicker(colorResult.hex)}
+												backgroundColor={primaryColorPicker}
+											/>
+											{!autoColourRange && (
 												<ColorPickerComponent
 													onColorChange={(colorResult) => setSecondaryColorPicker(colorResult.hex)}
-													backgroundColor = {secondaryColorPicker}
+													backgroundColor={secondaryColorPicker}
 												/>
-											</div>
-										)}
+											)}
+										</div>
 									</>
 								</>
 							) : (

--- a/client/src/components/sidebar.tsx
+++ b/client/src/components/sidebar.tsx
@@ -184,7 +184,7 @@ const Sidebar: React.FC<SidebarProps> = ({handleDownload, geoJsonData}) => {
 							{group.id === "1" ? (
 								<>
 									<>
-										<label htmlFor={`checkbox-${group.id}`} className="menu-item-label">
+										<label className="menu-item-label">
 											{group.name}
 										</label>
 										<ColorPickerComponent
@@ -200,7 +200,7 @@ const Sidebar: React.FC<SidebarProps> = ({handleDownload, geoJsonData}) => {
 										</button>
 										{isMonochromeMap && (
 											<div>
-												<label htmlFor={`checkbox-${group.id}`} className="menu-item-label">
+												<label className="menu-item-label">
 													{group.name}
 												</label>
 												<ColorPickerComponent

--- a/client/src/contexts/toggleContext.tsx
+++ b/client/src/contexts/toggleContext.tsx
@@ -17,10 +17,10 @@ type ToggleContextType = {
 	setIsUploadedFileVisible: (isVisible: boolean) => void;
 	uploadedFile            : UploadFileData | null;
 	setUploadedFile         : (file: UploadFileData | null) => void;
-	colorPickerColor        : string;
-	setColorPickerColor     : (color: string) => void;
-	colorPickerColor_2      : string;
-	setColorPickerColor_2   : (color: string) => void;
+	primaryColorPicker        : string;
+	setPrimaryColorPicker     : (color: string) => void;
+	secondaryColorPicker      : string;
+	setSecondaryColorPicker   : (color: string) => void;
 	isMonochromeMap			: boolean;
 	setIsMonochromeMap		: (isMonochrome: boolean) => void;
 	uploadedFiles           : UploadFileData[];
@@ -41,10 +41,10 @@ const defaultState: ToggleContextType = {
 	setIsUploadedFileVisible: () => {},
 	uploadedFile            : null,
 	setUploadedFile         : () => {},
-	colorPickerColor        : "#98AFC7",
-	setColorPickerColor     : () => {},
-	colorPickerColor_2      : "#98AFC7",
-	setColorPickerColor_2   : () => {},
+	primaryColorPicker        : "#98AFC7",
+	setPrimaryColorPicker     : () => {},
+	secondaryColorPicker      : "#98AFC7",
+	setSecondaryColorPicker   : () => {},
 	isMonochromeMap			: true,
 	setIsMonochromeMap		: () => {},
 	uploadedFiles           : [],
@@ -68,8 +68,8 @@ export const ToggleProvider: React.FC<{ children: React.ReactNode }> = ({ childr
 		defaultState.isUploadedFileVisible
 	);
 	const [uploadedFile, setUploadedFile]   = useState(defaultState.uploadedFile);
-	const [colorPickerColor, setColorPickerColor]           = useState(defaultState.colorPickerColor);
-	const [colorPickerColor_2, setColorPickerColor_2]           = useState(defaultState.colorPickerColor_2);
+	const [primaryColorPicker, setPrimaryColorPicker]           = useState(defaultState.primaryColorPicker);
+	const [secondaryColorPicker, setSecondaryColorPicker]           = useState(defaultState.secondaryColorPicker);
 	const [isMonochromeMap, setIsMonochromeMap] = useState(defaultState.isMonochromeMap);
 	const [uploadedFiles, setUploadedFiles] = useState(
 		defaultState.uploadedFiles
@@ -155,10 +155,10 @@ export const ToggleProvider: React.FC<{ children: React.ReactNode }> = ({ childr
 				setIsUploadedFileVisible,
 				uploadedFile,
 				setUploadedFile,
-				colorPickerColor,
-				setColorPickerColor,
-				colorPickerColor_2,
-				setColorPickerColor_2,
+				primaryColorPicker,
+				setPrimaryColorPicker,
+				secondaryColorPicker,
+				setSecondaryColorPicker,
 				isMonochromeMap,
 				setIsMonochromeMap,
 				uploadedFiles,

--- a/client/src/contexts/toggleContext.tsx
+++ b/client/src/contexts/toggleContext.tsx
@@ -19,6 +19,10 @@ type ToggleContextType = {
 	setUploadedFile         : (file: UploadFileData | null) => void;
 	colorPickerColor        : string;
 	setColorPickerColor     : (color: string) => void;
+	colorPickerColor_2      : string;
+	setColorPickerColor_2   : (color: string) => void;
+	isMonochromeMap			: boolean;
+	setIsMonochromeMap		: (isMonochrome: boolean) => void;
 	uploadedFiles           : UploadFileData[];
 	setUploadedFiles        : (files: UploadFileData[]) => void;
 	currentFileIndex        : number;
@@ -39,6 +43,10 @@ const defaultState: ToggleContextType = {
 	setUploadedFile         : () => {},
 	colorPickerColor        : "#98AFC7",
 	setColorPickerColor     : () => {},
+	colorPickerColor_2      : "#98AFC7",
+	setColorPickerColor_2   : () => {},
+	isMonochromeMap			: true,
+	setIsMonochromeMap		: () => {},
 	uploadedFiles           : [],
 	setUploadedFiles        : () => {},
 	currentFileIndex        : 0,
@@ -61,6 +69,8 @@ export const ToggleProvider: React.FC<{ children: React.ReactNode }> = ({ childr
 	);
 	const [uploadedFile, setUploadedFile]   = useState(defaultState.uploadedFile);
 	const [colorPickerColor, setColorPickerColor]           = useState(defaultState.colorPickerColor);
+	const [colorPickerColor_2, setColorPickerColor_2]           = useState(defaultState.colorPickerColor_2);
+	const [isMonochromeMap, setIsMonochromeMap] = useState(defaultState.isMonochromeMap);
 	const [uploadedFiles, setUploadedFiles] = useState(
 		defaultState.uploadedFiles
 	);
@@ -147,6 +157,10 @@ export const ToggleProvider: React.FC<{ children: React.ReactNode }> = ({ childr
 				setUploadedFile,
 				colorPickerColor,
 				setColorPickerColor,
+				colorPickerColor_2,
+				setColorPickerColor_2,
+				isMonochromeMap,
+				setIsMonochromeMap,
 				uploadedFiles,
 				setUploadedFiles,
 				currentFileIndex,

--- a/client/src/contexts/toggleContext.tsx
+++ b/client/src/contexts/toggleContext.tsx
@@ -21,8 +21,8 @@ type ToggleContextType = {
 	setPrimaryColorPicker     : (color: string) => void;
 	secondaryColorPicker      : string;
 	setSecondaryColorPicker   : (color: string) => void;
-	isMonochromeMap			: boolean;
-	setIsMonochromeMap		: (isMonochrome: boolean) => void;
+	autoColourRange			: boolean;
+	setAutoColourRange		: (isMonochrome: boolean) => void;
 	uploadedFiles           : UploadFileData[];
 	setUploadedFiles        : (files: UploadFileData[]) => void;
 	currentFileIndex        : number;
@@ -45,8 +45,8 @@ const defaultState: ToggleContextType = {
 	setPrimaryColorPicker     : () => {},
 	secondaryColorPicker      : "#98AFC7",
 	setSecondaryColorPicker   : () => {},
-	isMonochromeMap			: true,
-	setIsMonochromeMap		: () => {},
+	autoColourRange			: true,
+	setAutoColourRange		: () => {},
 	uploadedFiles           : [],
 	setUploadedFiles        : () => {},
 	currentFileIndex        : 0,
@@ -70,7 +70,7 @@ export const ToggleProvider: React.FC<{ children: React.ReactNode }> = ({ childr
 	const [uploadedFile, setUploadedFile]   = useState(defaultState.uploadedFile);
 	const [primaryColorPicker, setPrimaryColorPicker]           = useState(defaultState.primaryColorPicker);
 	const [secondaryColorPicker, setSecondaryColorPicker]           = useState(defaultState.secondaryColorPicker);
-	const [isMonochromeMap, setIsMonochromeMap] = useState(defaultState.isMonochromeMap);
+	const [autoColourRange, setAutoColourRange] = useState(defaultState.autoColourRange);
 	const [uploadedFiles, setUploadedFiles] = useState(
 		defaultState.uploadedFiles
 	);
@@ -159,8 +159,8 @@ export const ToggleProvider: React.FC<{ children: React.ReactNode }> = ({ childr
 				setPrimaryColorPicker,
 				secondaryColorPicker,
 				setSecondaryColorPicker,
-				isMonochromeMap,
-				setIsMonochromeMap,
+				autoColourRange,
+				setAutoColourRange,
 				uploadedFiles,
 				setUploadedFiles,
 				currentFileIndex,

--- a/client/src/utils/colourUtils.ts
+++ b/client/src/utils/colourUtils.ts
@@ -40,9 +40,10 @@ export function generateColorGradient(
     
     // Push white color for 0
     gradientColors.push('rgb(255, 255, 255)');
+    gradientColors.push(startColor);
 
     // Generate the gradient colors for other steps
-    for (let i = 1; i <= numSteps; i++) {
+    for (let i = 2; i <= numSteps; i++) {
         const r: number = Math.round(startRGB[0] + stepSize[0] * i);
         const g: number = Math.round(startRGB[1] + stepSize[1] * i);
         const b: number = Math.round(startRGB[2] + stepSize[2] * i);

--- a/client/src/utils/colourUtils.ts
+++ b/client/src/utils/colourUtils.ts
@@ -4,10 +4,28 @@ import { RGBColor } from "react-color";
 export function generateColorGradient(
     numSteps: number = 10,
     startColor: string = 'rgb(152, 175, 199)',
-    endColor: string = 'rgb(72, 19, 102)'
+    endColor: string = 'null'
 ): string[] {
     // Parse the start and end colors
     const startRGB: number[] = parseRGB(startColor);
+
+    // Calculate the end color based on the start color values
+    if(endColor == 'null' || endColor == 'rgb(NaN, NaN, NaN)'){
+        endColor = 'rgb(';
+            for (let i = 0; i < startRGB.length; i++) {
+                if (startRGB[i] > 153) {
+                    endColor += (startRGB[i] - 153).toString();
+                } else {
+                    endColor += (startRGB[i] + 153).toString();
+                }
+                if (i < startRGB.length - 1) {
+                    endColor += ', ';
+                }
+            }
+        endColor += ')';
+    }
+    
+    // Parse the end color
     const endRGB: number[] = parseRGB(endColor);
     
     // Calculate the step size for each color channel 

--- a/client/src/utils/colourUtils.ts
+++ b/client/src/utils/colourUtils.ts
@@ -4,13 +4,14 @@ import { RGBColor } from "react-color";
 export function generateColorGradient(
     numSteps: number = 10,
     startColor: string = 'rgb(152, 175, 199)',
-    endColor: string = 'null'
+    endColor: string = 'null',
+    calcMonochrome: boolean
 ): string[] {
     // Parse the start and end colors
     const startRGB: number[] = parseRGB(startColor);
 
     // Calculate the end color based on the start color values
-    if(endColor == 'null' || endColor == 'rgb(NaN, NaN, NaN)'){
+    if(calcMonochrome){
         endColor = 'rgb(';
             for (let i = 0; i < startRGB.length; i++) {
                 if (startRGB[i] > 153) {


### PR DESCRIPTION
#### Things done:
- Update colour picker section of sidebar to accommodate multiple colour inputs. 
    - Sidebar now handles either second colour input or calculates a range of colours based on primary colour selection.
- Correct map colour logic
    - Bug was found where primary colour wasn’t included in data colour gradient. This was fixed.
- Add toggle component
    - Toggle button to switch between methods of map colour generation.

#### Things to consider:
- UI of colour picker could be redone to make more intuitive. 
- Add info tool tip on how colour picker works?